### PR TITLE
Improve HF integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,23 @@ Check out our interactive demo on Hugging Face:
 
 #### (2) Run the Gradio Demo Locally
 
-Download the model weights manually from [Google Drive](https://drive.google.com/file/d/1NBdq7A1QMFGhIbpK1HT3ATv2S1jXWr2h/view?usp=drive_link), or run the following commands:
+Download the model weights manually from [Hugging Face](https://huggingface.co/qitaoz/DiffusionSfM):
 
+```python
+from huggingface_hub import hf_hub_download
+
+filepath = hf_hub_download(repo_id="qitaoz/DiffusionSfM", filename="qitaoz/DiffusionSfM")
 ```
+
+or [Google Drive](https://drive.google.com/file/d/1NBdq7A1QMFGhIbpK1HT3ATv2S1jXWr2h/view?usp=drive_link):
+
+```bash
 gdown https://drive.google.com/uc\?id\=1NBdq7A1QMFGhIbpK1HT3ATv2S1jXWr2h
 unzip models.zip
+```
+Next run the demo like so:
 
+```bash
 # first-time running may take a longer time
 python gradio_app.py
 ```

--- a/diffusionsfm/model/diffuser.py
+++ b/diffusionsfm/model/diffuser.py
@@ -7,8 +7,14 @@ from diffusionsfm.model.dit import DiT
 from diffusionsfm.model.feature_extractors import PretrainedVAE, SpatialDino
 from diffusionsfm.model.scheduler import NoiseScheduler
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class RayDiffuser(nn.Module):
+
+class RayDiffuser(nn.Module, PyTorchModelHubMixin,
+                  repo_url="https://github.com/QitaoZhao/DiffusionSfM",
+                  paper_url="https://huggingface.co/papers/2505.05473",
+                  pipeline_tag="image-to-3d",
+                  license="mit"):
     def __init__(
         self,
         model_type="dit",

--- a/diffusionsfm/model/diffuser_dpt.py
+++ b/diffusionsfm/model/diffuser_dpt.py
@@ -8,6 +8,8 @@ from diffusionsfm.model.feature_extractors import PretrainedVAE, SpatialDino
 from diffusionsfm.model.blocks import _make_fusion_block, _make_scratch
 from diffusionsfm.model.scheduler import NoiseScheduler
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 # functional implementation
 def nearest_neighbor_upsample(x: torch.Tensor, scale_factor: int):
@@ -35,7 +37,11 @@ class ProjectReadout(nn.Module):
         return self.project(features)
 
 
-class RayDiffuserDPT(nn.Module):
+class RayDiffuserDPT(nn.Module, PyTorchModelHubMixin,
+                        repo_url="https://github.com/QitaoZhao/DiffusionSfM",
+                        paper_url="https://huggingface.co/papers/2505.05473",
+                        pipeline_tag="image-to-3d",
+                        license="mit"):
     def __init__(
         self,
         model_type="dit",


### PR DESCRIPTION
This PR  equips the main model classes with:

* `from_pretrained`, `save_pretrained`and`push_to_hub` capabilities
* `safetensors` for weights serialization (if you do `model.save_pretrained("...")` or `model.push_to_hub("...")`)
* track download numbers for models pushed to the hub, similar to models in the Transformers library
* push an automated model card.

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from diffusionsfm.inference.load_model import load_model
from diffusionsfm.model.diffuser import RayDiffuser

# load model
model, cfg = load_model(".", device="cpu")

# save it locally like so
model.save_pretrained("my-diffusion-sm-model")

# or push a trained model to the hub
model.push_to_hub("qitaoz/DiffusionSfM")

# now anyone can use it like so
model = RayDiffuser.from_pretrained("qitaoz/DiffusionSfM")
```